### PR TITLE
This PR turns variant groups into "first class" civic entities.

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,5 @@
 class CommentsController < ApplicationController
+  include WithComment
   skip_before_filter :ensure_signed_in, only: [:index, :show]
 
   def index
@@ -41,10 +42,5 @@ class CommentsController < ApplicationController
     else
       render json: CommentPresenter.new(comment), status: :unprocessable_entity
     end
-  end
-
-  private
-  def comment_params
-    params.permit(:title, :text)
   end
 end

--- a/app/controllers/concerns/with_comment.rb
+++ b/app/controllers/concerns/with_comment.rb
@@ -1,0 +1,13 @@
+module WithComment
+  extend ActiveSupport::Concern
+
+  def comment_params
+    params[:comment].permit(:title, :text)
+  end
+
+  def attach_comment(obj)
+    if not comment_params.blank?
+      Comment.create(comment_params.merge({ user: current_user, commentable: obj }))
+    end
+  end
+end

--- a/app/controllers/evidence_items_controller.rb
+++ b/app/controllers/evidence_items_controller.rb
@@ -1,4 +1,5 @@
 class EvidenceItemsController < ApplicationController
+  include WithComment
   actions_without_auth :index, :show, :variant_index
 
   def index
@@ -62,15 +63,5 @@ class EvidenceItemsController < ApplicationController
 
   def foreign_key_params
     params.permit(:evidence_type, :evidence_level, :variant_origin)
-  end
-
-  def comment_params
-    params[:comment].permit(:text, :title)
-  end
-
-  def attach_comment(item)
-    if not comment_params.blank?
-      Comment.create(comment_params.merge({ user: current_user, commentable: item }))
-    end
   end
 end

--- a/app/controllers/genes_controller.rb
+++ b/app/controllers/genes_controller.rb
@@ -1,4 +1,5 @@
 class GenesController < ApplicationController
+  include WithComment
   actions_without_auth :index, :show, :mygene_info_proxy, :datatable
 
   def index
@@ -64,16 +65,6 @@ class GenesController < ApplicationController
   private
   def gene_params
     params.permit(:clinical_description, :description)
-  end
-
-  def comment_params
-    params[:comment].permit(:text, :title)
-  end
-
-  def attach_comment(gene)
-    if not comment_params.blank?
-      Comment.create(comment_params.merge({ user: current_user, commentable: gene }))
-    end
   end
 
   def my_gene_info_url(entrez_id)

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -1,4 +1,5 @@
 class ModerationsController < ApplicationController
+  include WithComment
   actions_without_auth :index, :show
 
   def show
@@ -62,16 +63,5 @@ class ModerationsController < ApplicationController
     suggested_change.save
     attach_comment(suggested_change)
     render json: presenter_class.new(suggested_change.moderated)
-  end
-
-  private
-  def comment_params
-    params.permit(comment: [:title, :text])[:comment]
-  end
-
-  def attach_comment(suggested_change)
-    if not comment_params.blank?
-      Comment.create comment_params.merge({ user: current_user, commentable: suggested_change })
-    end
   end
 end

--- a/app/controllers/variant_group_audits_controller.rb
+++ b/app/controllers/variant_group_audits_controller.rb
@@ -1,0 +1,6 @@
+class VariantGroupAuditsController < AuditsController
+  private
+  def audited_object
+    VariantGroup.find_by!(id: params[:variant_group_id])
+  end
+end

--- a/app/controllers/variant_group_comments_controller.rb
+++ b/app/controllers/variant_group_comments_controller.rb
@@ -1,0 +1,6 @@
+class VariantGroupCommentsController < CommentsController
+  private
+  def commentable
+    VariantGroup.find_by!(id: params[:variant_group_id])
+  end
+end

--- a/app/controllers/variant_group_moderations_controller.rb
+++ b/app/controllers/variant_group_moderations_controller.rb
@@ -1,0 +1,16 @@
+class VariantGroupModerationsController < ModerationsController
+
+  private
+  def moderated_object
+    VariantGroup.find_by!(id: params[:variant_group_id])
+  end
+
+  def moderation_params
+    params.permit(:name, :description)
+  end
+
+  def presenter_class
+    VariantGroupPresenter
+  end
+
+end

--- a/app/controllers/variant_groups_controller.rb
+++ b/app/controllers/variant_groups_controller.rb
@@ -38,6 +38,7 @@ class VariantGroupsController < ApplicationController
 
   def update
     variant_group = VariantGroup.view_scope.find_by!(id: params[:id])
+    authorize variant_group
     status = if variant_group.update_attributes(variant_group_params)
                :ok
              else

--- a/app/controllers/variant_groups_controller.rb
+++ b/app/controllers/variant_groups_controller.rb
@@ -35,4 +35,20 @@ class VariantGroupsController < ApplicationController
     variant_group = VariantGroup.view_scope.find(params[:id])
     render json: VariantGroupPresenter.new(variant_group, true)
   end
+
+  def update
+    variant_group = VariantGroup.view_scope.find_by!(id: params[:id])
+    status = if variant_group.update_attributes(variant_group_params)
+               :ok
+             else
+               :unprocessable_entity
+             end
+    attach_comment(variant_group)
+
+    render json: VariantGroupPresenter.new(variant_group), status: status
+  end
+
+  def variant_group_params
+    params.permit(:name, :description)
+  end
 end

--- a/app/controllers/variants_controller.rb
+++ b/app/controllers/variants_controller.rb
@@ -18,6 +18,17 @@ class VariantsController < ApplicationController
     render json: variants.map { |v| VariantPresenter.new(v, true, true) }
   end
 
+  def variant_group_index
+    variants = Variant.view_scope
+      .page(params[:page].to_i)
+      .per(params[:count].to_i)
+      .joins(:variant_groups)
+      .where(variant_groups: { id: params[:variant_id] })
+      .uniq
+
+    render json: variants.map { |v| VariantPresenter.new(v, true, true) }
+  end
+
   def show
     variant = Variant.view_scope.find_by!(id: params[:id])
     render json: VariantPresenter.new(variant, true, true, true)

--- a/app/controllers/variants_controller.rb
+++ b/app/controllers/variants_controller.rb
@@ -1,4 +1,5 @@
 class VariantsController < ApplicationController
+  include WithComment
   actions_without_auth :index, :show, :typeahead_results, :datatable, :gene_index
 
   def index
@@ -57,15 +58,5 @@ class VariantsController < ApplicationController
   private
   def variant_params
     params.permit(:name, :description)
-  end
-
-  def comment_params
-    params[:comment].permit(:title, :text)
-  end
-
-  def attach_comment(variant)
-    if not comment_params.blank?
-      Comment.create(comment_params.merge({ user: current_user, commentable: variant }))
-    end
   end
 end

--- a/app/models/variant_group.rb
+++ b/app/models/variant_group.rb
@@ -1,4 +1,9 @@
 class VariantGroup < ActiveRecord::Base
+  include Moderated
+  include Subscribable
+  acts_as_commentable
+  audited except: [:created_at, :updated_at], allow_mass_assignment: true
+
   has_many :variant_group_variants
   has_many :variants, through: :variant_group_variants
 

--- a/app/policies/variant_group_policy.rb
+++ b/app/policies/variant_group_policy.rb
@@ -1,0 +1,5 @@
+class VariantGroupPolicy < Struct.new(:user, :variant_group)
+  def update?
+    user.is_admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,12 @@ Rails.application.routes.draw do
       end
     end
 
-    resources 'variant_groups', only: [:index, :show]
+    resources 'variant_groups', except: [:edit, :new] do
+      get 'variants' => 'variants#variant_group_index'
+      concerns :audited, controller: 'variant_group_audits'
+      concerns :moderated, controller: 'variant_group_moderations'
+      concerns :commentable, controller: 'variant_group_comments'
+    end
 
     resources 'genes', except: [:edit, :new] do
       get 'variants' => 'variants#gene_index'


### PR DESCRIPTION
Variant groups can now be edited, commented on, have changes suggested, and their version history is tracked.

Proposing brand new ones will come along with the improved flow for proposing new Genes, Evidence Items, etc...