### PR TITLE
Preserve ability to query by entrez_id

### DIFF
--- a/app/controllers/genes_controller.rb
+++ b/app/controllers/genes_controller.rb
@@ -1,6 +1,6 @@
 class GenesController < ApplicationController
   include WithComment
-  actions_without_auth :index, :show, :mygene_info_proxy, :datatable
+  actions_without_auth :index, :show, :mygene_info_proxy, :datatable, :entrez_show
 
   def index
     genes = Gene.view_scope
@@ -26,6 +26,12 @@ class GenesController < ApplicationController
     gene = Gene.view_scope.find_by!(id: params[:id])
     render json: GenePresenter.new(gene, true)
   end
+
+  def entrez_show
+    gene = Gene.view_scope.find_by!(entrez_id: params[:entrez_id]) 
+    render json: GenePresenter.new(gene, true)
+  end
+
 
   def update
     gene = Gene.view_scope.find_by!(id: params[:id])

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -18,13 +18,13 @@ class ModerationsController < ApplicationController
     mo = moderated_object
     mo.assign_attributes(moderation_params)
     suggested_change = mo.suggest_change!(current_user)
+    authorize suggested_change
     attach_comment(suggested_change)
     create_event(suggested_change, 'change suggested')
     render json: SuggestedChangePresenter.new(suggested_change)
   rescue NoSuggestedChangesError => e
-      render json: e, status: :unprocessable_entity
-  ensure
-    authorize suggested_change
+    skip_authorization
+    render json: e, status: :conflict
   end
 
   def update

--- a/app/controllers/variants_controller.rb
+++ b/app/controllers/variants_controller.rb
@@ -1,6 +1,6 @@
 class VariantsController < ApplicationController
   include WithComment
-  actions_without_auth :index, :show, :typeahead_results, :datatable, :gene_index
+  actions_without_auth :index, :show, :typeahead_results, :datatable, :gene_index, :entrez_gene_index
 
   def index
     variants = Variant.view_scope
@@ -18,6 +18,17 @@ class VariantsController < ApplicationController
 
     render json: variants.map { |v| VariantPresenter.new(v, true, true) }
   end
+
+  def entrez_gene_index
+    puts params[:gene_entrez_id]
+    variants = Variant.view_scope
+      .page(params[:page].to_i)
+      .per(params[:count].to_i)
+      .where(genes: { entrez_id: params[:gene_entrez_id] })
+
+    render json: variants.map { |v| VariantPresenter.new(v, true, true) }
+  end
+
 
   def variant_group_index
     variants = Variant.view_scope

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
 
     get '/text/:term' => 'text#show'
     get '/text' => 'text#index'
+    
+    get '/ccc/genes/:gene_entrez_id/variants' =>  'variants#entrez_gene_index'
+    get '/ccc/genes/:entrez_id' =>  'genes#entrez_show'
+
 
     concern :audited do |options|
       get 'revisions/last' => "#{options[:controller]}#last"

--- a/spec/controllers/ccc_spec.rb
+++ b/spec/controllers/ccc_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe GenesController do
+  it 'should lookup by entrez_id or id' do
+    gene = Fabricate(:gene)
+
+    get :entrez_show, entrez_id: gene.entrez_id
+
+    result = JSON.parse(response.body)
+    expect(result['id']).to eq gene.id
+    expect(result['entrez_id']).to eq gene.entrez_id
+
+
+    get :show, id: gene.id
+
+    result = JSON.parse(response.body)
+    expect(result['id']).to eq gene.id
+    expect(result['entrez_id']).to eq gene.entrez_id
+
+  end
+end
+
+
+
+
+describe VariantsController do
+  it 'should lookup by entrez_id or id' do
+    gene = Fabricate(:gene)
+    gene.variants << Fabricate(:variant)
+
+    get :entrez_gene_index, entrez_gene_id: gene.entrez_id
+
+    result = JSON.parse(response.body)
+    expect(result.length).to eq gene.variants.length
+    expect(result[0]['id']).to eq gene.variants[0]['id']
+
+
+    get :gene_index, gene_id: gene.id
+
+    result = JSON.parse(response.body)
+    expect(result.length).to eq gene.variants.length
+    expect(result[0]['id']).to eq gene.variants[0]['id']
+
+  end
+end


### PR DESCRIPTION
As part of integrating with the Collaborative Cancer Cloud (CCC) with CIViC, we've come to rely on the entrez_id as the mechanism to link the MAF files produced by the pipeline with the CIViC web app.

Thanks for your time.