### PR TITLE
add to /api/ccc apito support batch

### DIFF
--- a/app/controllers/evidence_items_controller.rb
+++ b/app/controllers/evidence_items_controller.rb
@@ -1,6 +1,6 @@
 class EvidenceItemsController < ApplicationController
   include WithComment
-  actions_without_auth :index, :show, :variant_index
+  actions_without_auth :index, :show, :variant_index, :variant_hgvs_index
 
   def index
     items = EvidenceItem.view_scope
@@ -24,6 +24,11 @@ class EvidenceItemsController < ApplicationController
       .where(variants: { id: params[:variant_id] })
 
     render json: items.map { |item| EvidenceItemPresenter.new(item) }
+  end
+
+  def variant_hgvs_index
+    json = EvidenceItem.where.not(:variant_hgvs => "N/A").pluck(:variant_hgvs,:variant_id,:id).to_json
+    render json: json
   end
 
   def propose

--- a/app/controllers/genes_controller.rb
+++ b/app/controllers/genes_controller.rb
@@ -1,6 +1,6 @@
 class GenesController < ApplicationController
   include WithComment
-  actions_without_auth :index, :show, :mygene_info_proxy, :datatable, :entrez_show
+  actions_without_auth :index, :show, :mygene_info_proxy, :datatable, :entrez_show, :entrez_index
 
   def index
     genes = Gene.view_scope
@@ -32,6 +32,10 @@ class GenesController < ApplicationController
     render json: GenePresenter.new(gene, true)
   end
 
+  def entrez_index
+    json = Gene.pluck(:entrez_id,:id).to_json
+    render json: json
+  end
 
   def update
     gene = Gene.view_scope.find_by!(id: params[:id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
     scope 'ccc' do
       get 'genes/:entrez_id/variants' =>  'variants#entrez_gene_index'
       get 'genes/:entrez_id' =>  'genes#entrez_show'
+      get 'entrez_ids' =>  'genes#entrez_index'
+      get 'variant_hgvs' =>  'evidence_items#variant_hgvs_index'
+      
     end
 
     scope 'stats' do

--- a/spec/controllers/ccc_spec.rb
+++ b/spec/controllers/ccc_spec.rb
@@ -18,6 +18,19 @@ describe GenesController do
     expect(result['entrez_id']).to eq gene.entrez_id
 
   end
+
+
+  it 'should return a list of all entrez_ids and gene_ids' do
+    gene = Fabricate(:gene)
+
+    get :entrez_index 
+
+    result = JSON.parse(response.body)
+    expect(result.length).to eq 1
+    expect(result[0][0]).to eq gene.entrez_id
+    expect(result[0][1]).to eq gene.id
+
+  end  
 end
 
 
@@ -42,4 +55,21 @@ describe VariantsController do
     expect(result[0]['id']).to eq gene.variants[0]['id']
 
   end
+end
+
+
+describe EvidenceItemsController do
+
+  it 'should return a list of all entrez_ids and gene_ids' do
+    evidence_item = Fabricate(:evidence_item)
+
+    get :variant_hgvs_index 
+
+    result = JSON.parse(response.body)
+    expect(result.length).to eq 1
+    expect(result[0][0]).to eq evidence_item.variant_hgvs
+    expect(result[0][1]).to eq evidence_item.variant.id
+    expect(result[0][2]).to eq evidence_item.id
+
+  end  
 end


### PR DESCRIPTION

```
 “As a Clinician or Researcher, when my CCC workflow completes, I need to see the literature and provenance for a genomic feature.”

```

The CCC workflow terminates with a MAF file.  Some of these MAF files are quite large (+150K lines)
Therefore querying CIViC for each gene is prohibitive.   This change allows the CCC workflow to query CIViC twice, once for the entrez_ids and a second time for the genomic locations.



![image](https://cloud.githubusercontent.com/assets/47808/7716712/bdb03942-fe4a-11e4-82b6-a85f7f701a31.png)

