### PR TITLE
Added ability to search integer fields for null values

### DIFF
--- a/app/models/advanced_searches/base.rb
+++ b/app/models/advanced_searches/base.rb
@@ -56,7 +56,8 @@ module AdvancedSearches
         'begins_with' => '%s ILIKE ?',
         'does_not_contain' => '%s NOT ILIKE ?',
         'is_in_the_range' => '%1$s >= ? AND %1$s <= ?',
-        'is_empty' => "TRIM(%1$s) = '' OR %1$s IS NULL"
+        'is_empty' => "TRIM(%1$s) = '' OR %1$s IS NULL",
+        'is_undefined' => "%1$s IS NULL"
       }
       sprintf(@comparison_fragments[operation_type], column)
     end


### PR DESCRIPTION
Backend change for genome/civic-client#648

It's really similar to the is_empty comparison, but TRIM() can't take integers and I couldn't think of a way to modify the existing comparison to keep it's original function while also accepting integer fields as input