### PR TITLE
Fixed issue with IS NOT search in clinical significance

### DIFF
--- a/app/models/advanced_searches/evidence_item.rb
+++ b/app/models/advanced_searches/evidence_item.rb
@@ -43,7 +43,7 @@ module AdvancedSearches
 
     def handle_clinical_significance(operation_type, parameters)
       [
-        [comparison(reverse_operation_type(operation_type), 'evidence_items.clinical_significance')],
+        [comparison(operation_type, 'evidence_items.clinical_significance')],
         ::EvidenceItem.clinical_significances[parameters.first]
       ]
     end


### PR DESCRIPTION
Searching evidence items for 'Clinical Significance is not ...' replies with HTTP 500

I can't link directly to the search but you can go [here](https://civic.genome.wustl.edu/#/search/evidence/a365e757-c530-4350-82f5-5c2cfa2928b3) and change the condition from `is` to `is not`