### PR TITLE
Enabled searching evidence by pmc_id

### DIFF
--- a/app/models/advanced_searches/evidence_item.rb
+++ b/app/models/advanced_searches/evidence_item.rb
@@ -23,6 +23,7 @@ module AdvancedSearches
         'drug_id' => default_handler.curry['drugs.pubchem_id'],
         'gene_name' => default_handler.curry['genes.name'],
         'pubmed_id' => default_handler.curry['sources.pubmed_id'],
+        'pmc_id' => default_handler.curry['sources.pmc_id'],
         'rating' => default_handler.curry['evidence_items.rating'],
         'variant_name' => default_handler.curry['variants.name'],
         'variant_alias' => default_handler.curry['variant_aliases.name'],


### PR DESCRIPTION
@acoffman I know you mentioned scrapers in genome/civic-client#660, so I don't know if you think there's more functionality that needs to be added with regards to pmcid's.  This was just the base change to have the server respond to the pmcid searches