### PR TITLE
update version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module CivicServer
 
     config.autoload_paths += %W(#{config.root}/lib)
 
-    config.data_dump_version = 9
+    config.data_dump_version = 10
     config.data_dump_path = File.join(Rails.root, 'db', 'data.sql')
 
     config.active_job.queue_adapter = :delayed_job


### PR DESCRIPTION
This is needed to update to the newest civic data dump. We should probably evaluate whether or not we actually want to keep this check for the civic:load task, especially if we start generating sanitized dumps on a regular basis.