### PR TITLE
stop-gap measure for #318 allows forced db updates from rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following will set up the server side application and load the database sche
 
 For convenience, a sanitized version of a recent database backup is provided for your local development environment. You can load it with the following command:
 
-    rake civic:load
+    rake civic:load[force]
 
 Finally, start the CIViC rails server
 

--- a/lib/database/upgrade.rb
+++ b/lib/database/upgrade.rb
@@ -1,10 +1,10 @@
 module Database
   class Upgrade
-    def self.upgrade_if_needed
+    def self.upgrade_if_needed (force = false)
       data_dump_version        = Rails.configuration.data_dump_version
       current_database_version = DataVersion.maximum(:version) || 0
 
-      if data_dump_version > current_database_version
+      if data_dump_version > current_database_version || force
         puts "Database out of date - loading the new data dump."
         Rake::Task['db:migrate'].execute
         truncate_tables

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,7 +1,7 @@
 namespace :civic do
   desc 'if the current data dump is newer than the contents of the database, this loads the newer data dump'
-  task :load, [] => :environment do |_, args|
-    Database::Upgrade.upgrade_if_needed
+  task :load, [:force] => :environment do |_, args|
+    Database::Upgrade.upgrade_if_needed args[:force]
     if Rails.env.production?
       Dir.chdir(Rails.root) do
         system('bin/delayed_job', '-n 3', 'restart')


### PR DESCRIPTION
Allows the use of `rake civic:load[force]` to disregard version in database update. Does not change behavior of `rake civic:load` without options.